### PR TITLE
Added new ssl_want_read() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ax_port_malloc
 ax_port_calloc
 ax_port_realloc
 ax_port_free
+ax_port_pending
 ax_port_read
 ax_port_write
 ax_port_open

--- a/ssl/os_port.h
+++ b/ssl/os_port.h
@@ -76,6 +76,7 @@ extern "C" {
 #define SOCKET_READ(A,B,C)      ax_port_read(A,B,C)
 #define SOCKET_WRITE(A,B,C)     ax_port_write(A,B,C)
 #define SOCKET_CLOSE(A)         ax_port_close(A)
+#define SOCKET_PENDING(A)       ax_port_pending(A)
 #define get_file                ax_get_file
 #define EWOULDBLOCK EAGAIN
 

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007-2016, Cameron Rich
+ * Copyright (c) 2017, Diego Guerrero (ssl_want_write)
  * 
  * All rights reserved.
  * 
@@ -281,6 +282,19 @@ EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const uin
  * @param ssl [in] The ssl object reference.
  */
 EXP_FUNC void STDCALL ssl_free(SSL *ssl);
+
+/**
+ * @brief Check the rx buffer for new information.
+ * If the socket has new information to be read, 1 will be returned.
+ * Cheap alternative to check availability without actually decrypting.
+ * @param ssl [in] An SSL object reference.
+ * @return Read status:
+ * - if == 1, then there are bytes to be read,
+ * - if == 0, then there are not,
+ * - if < 0,  there was an error.
+ * @see ssl.h for the error code list.
+ */
+EXP_FUNC int STDCALL ssl_want_read(SSL *ssl);
 
 /**
  * @brief Read the SSL data stream.

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007-2016, Cameron Rich
+ * Copyright (c) 2017, Diego Guerrero (ssl_want_write)
  * 
  * All rights reserved.
  * 
@@ -290,6 +291,20 @@ EXP_FUNC void STDCALL ssl_free(SSL *ssl)
     ssl->extensions = NULL;
     free(ssl);
 }
+
+/*
+ * Check the rx buffer for new information.
+ */
+ EXP_FUNC int STDCALL ssl_want_read(SSL *ssl)
+ {
+     int ret = SOCKET_PENDING(ssl->client_fd);
+     
+     if (ret < 0) {
+         return ret;
+     }
+     
+     return ret > 0;
+ }
 
 /*
  * Read the SSL connection and send any alerts for various errors.


### PR DESCRIPTION
A new function has been introduced to know if the receiver buffer
has any information to be processed. The function delegates the
check to the external environment through the new dependency
ax_port_pending(). This later function should work similarly to the
openssl's SSL_pending(), which returns the number of available bytes
to be read from the rx stream, with the caveat that ax_port_pending()
must not decrypt the data to compute the availability, i.e. the
returned count may differ from openssl's implementation because of
encryption padding. This simplification is important to avoid
having an expensive operation just to check the state of the stream
(both in time and memory).

Since ax_port_pending can't make any promises about the final count
of decrypted bytes, ssl_want_read() only indicates whether there
is any available information at all, which is enough for most
situations.

Being able to check availability without touching the buffers makes
controlling the half-duplex nature of axTLS easier.